### PR TITLE
Add legacy fields to ElasticSearch index

### DIFF
--- a/src/process.js
+++ b/src/process.js
@@ -19,6 +19,10 @@ const {
 	ContentTypes,
 } = require("./constants")
 
+const {
+	decorateIndexWithLegacyProperties,
+} = require("./utils")
+
 const { IPFS_HOST, DATABASE_URL, ELASTIC_URL } = process.env
 
 const ipfs = IPFS({ host: IPFS_HOST, port: 443, protocol: "https" })
@@ -199,6 +203,8 @@ module.exports = async function(eventTime, Bucket, Key, data) {
 		elasticIndex.language = language
 	}
 
+	const decoratedElasticIndex = decorateIndexWithLegacyProperties(elasticIndex)
+
 	await Promise.all([
 		Assertion.create({
 			id,
@@ -219,7 +225,7 @@ module.exports = async function(eventTime, Bucket, Key, data) {
 			index: "documents",
 			type: "doc",
 			id: documentId,
-			body: elasticIndex,
+			body: decoratedElasticIndex,
 		}),
 	])
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,39 @@
+/**
+ * Decorates the index data structure with legacy fields possibly expected by Query Parser.
+ *
+ * If you add data to an ElasticSearch index in a specific structure, you will need to understand
+ * that structure in order to conduct complex search queries against it. We suspect that some of
+ * the v1 to v2 transition hiccups come from v2 composing index data in a different structure
+ * than v1's Query Parser expects when it composes the ElasticSearch query. As a way of verifying
+ * and testing this, this function decorates the index data we're already writing to
+ * ElasticSearch with additional fields we think Query Parser is trying to query.
+ *
+ * @param  {Object} index The original index
+ * @return {Object}       The index with additional legacy properties added
+ */
+const decorateIndexWithLegacyProperties = (index) => {
+  const {
+    fileUrl,
+    title,
+    publicationDate,
+    uploadDate
+  } = index
+  return Object.assign({}, index, {
+    custom_meta_data: {
+      url: fileUrl,
+      title: title,
+      publishDate: publicationDate || uploadDate,
+      publicationDate: publicationDate || uploadDate,
+    }
+    meta: {
+      date: publicationDate || uploadDate,
+      raw: {
+        UploadDate: uploadDate,
+      }
+    }
+  })
+}
+
+module.exports = {
+  decorateIndexWithLegacyProperties
+}


### PR DESCRIPTION
As part of debugging the issues between Query Parser and ElasticSearch, we’ve decided to add some legacy fields and data structures that Query Parser seems to expect when composing its query. This PR:

- Creates a utility function for decorating the existing index entries with legacy fields
- Creates a utilities file to contain this function
- Imports and uses this function to decorate the index before adding to ElasticSearch

Note that I’m unable to actually test this code since we have to package and deploy it to AWS, so… care should be taken in reviewing.

Resolves #1